### PR TITLE
pandas.DataFrame.ix is deprecated.

### DIFF
--- a/reskit/test/test_windpower.py
+++ b/reskit/test/test_windpower.py
@@ -51,7 +51,7 @@ def test_simulateTurbine():
 
     # Test choosing turbine by name
     p = simulateTurbine( windspeed, powerCurve="G80", loss=0.08)
-    perfG80 = np.array(TurbineLibrary.ix["G80"].PowerCurve)
+    perfG80 = np.array(TurbineLibrary.loc["G80"].PowerCurve)
     if abs(p.mean()-0.42599635)<1e-6: # Manually evaluated
         print("  Single simulation turbine identified by name: Success")
     else: raise RuntimeError("Single simulation turbine identified by name: Fail")

--- a/reskit/windpower/_powerCurveConvoluter.py
+++ b/reskit/windpower/_powerCurveConvoluter.py
@@ -8,7 +8,7 @@ def convolutePowerCurveByGuassian(powerCurve, stdScaling=0.06, stdBase=0.1, minS
     """
     # Set performance
     if isinstance(powerCurve,str): 
-        powerCurve = np.array(TurbineLibrary.ix[powerCurve].PowerCurve)
+        powerCurve = np.array(TurbineLibrary.loc[powerCurve].PowerCurve)
     elif isinstance(powerCurve, list):
         powerCurve = np.array(powerCurve)
 

--- a/reskit/windpower/_simulator.py
+++ b/reskit/windpower/_simulator.py
@@ -137,8 +137,8 @@ def simulateTurbine( windspeed, powerCurve=None, capacity=None, rotordiam=None, 
         cutoutWindSpeed = kwargs.pop("cutout", None)
         powerCurve = SyntheticPowerCurve(capacity=capacity, rotordiam=rotordiam, cutout=cutoutWindSpeed)
     elif isinstance(powerCurve,str): # Load a turbine from the TurbineLibrary
-        if capacity is None: capacity = TurbineLibrary.ix[powerCurve].Capacity
-        powerCurve = TurbineLibrary.ix[powerCurve].PowerCurve
+        if capacity is None: capacity = TurbineLibrary.loc[powerCurve].Capacity
+        powerCurve = TurbineLibrary.loc[powerCurve].PowerCurve
     elif isinstance(powerCurve, list):
         tmp = np.array(powerCurve)
         powerCurve = PowerCurve(tmp[:,0], tmp[:,1])

--- a/reskit/windpower/_workflow.py
+++ b/reskit/windpower/_workflow.py
@@ -236,13 +236,13 @@ def workflowTemplate(placements, source, landcover, gwa, convScale, convBase, lo
 
     elif isinstance(powerCurve, str):
         pcKey = pd.Series([powerCurve,] * placements.shape[0], index=placements)
-        capacity = pd.Series(TurbineLibrary.ix[powerCurve].Capacity, index=placements)
+        capacity = pd.Series(TurbineLibrary.loc[powerCurve].Capacity, index=placements)
 
-        tmp = TurbineLibrary.ix[powerCurve].Rotordiameter
+        tmp = TurbineLibrary.loc[powerCurve].Rotordiameter
         if isinstance(tmp,float): rotordiam = pd.Series(tmp, index=placements)
         else: rotordiam = 0
         
-        powerCurves[powerCurve] = TurbineLibrary.ix[powerCurve].PowerCurve
+        powerCurves[powerCurve] = TurbineLibrary.loc[powerCurve].PowerCurve
 
     else: # powerCurve is either a (ws,power) list or is a list of turbine names
         if isinstance(powerCurve[0],str): # assume entire list is a list of names
@@ -252,14 +252,14 @@ def workflowTemplate(placements, source, landcover, gwa, convScale, convBase, lo
 
             for name in pcKey:
                 # TODO: I SHOULD CHECK FOR THE "spPow:cutout" notation here, so that library and synthetic turbines can be mixed 
-                capacity.append(TurbineLibrary.ix[name].Capacity)
+                capacity.append(TurbineLibrary.loc[name].Capacity)
 
-                tmp = TurbineLibrary.ix[powerCurve].Rotordiameter
+                tmp = TurbineLibrary.loc[powerCurve].Rotordiameter
                 if isinstance(tmp,float): rotordiam = pd.Series(tmp, index=placements)
                 else: rotordiam = 0
 
                 if not name in powerCurves:
-                    powerCurves[name] = TurbineLibrary.ix[name].PowerCurve
+                    powerCurves[name] = TurbineLibrary.loc[name].PowerCurve
 
             capacity = pd.Series(capacity, index=placements)
             rotordiam = pd.Series(rotordiam, index=placements)


### PR DESCRIPTION
An AttributError 'DataFrame' object has no attribute 'ix' comes up if a real turbine power curve from windpower.Turbinelibrary is used for the simulation. (as in example 3.05d)

As of pandas 1.0 it is no longer possible to use pandas.DataFrame.ix.
Changing .ix to .loc within the code seems to be enough to fix the problem.