### PR TITLE
Update _powerCurveConvoluter.py

### DIFF
--- a/reskit/windpower/_powerCurveConvoluter.py
+++ b/reskit/windpower/_powerCurveConvoluter.py
@@ -8,7 +8,7 @@ def convolutePowerCurveByGuassian(powerCurve, stdScaling=0.06, stdBase=0.1, minS
     """
     # Set performance
     if isinstance(powerCurve,str): 
-        powerCurve = np.array(TurbineLibrary.loc[powerCurve].PowerCurve)
+        powerCurve = TurbineLibrary.loc[powerCurve].PowerCurve # Edited to not use np.array. Otherwise it cause an error
     elif isinstance(powerCurve, list):
         powerCurve = np.array(powerCurve)
 


### PR DESCRIPTION
Hi. I found that a small change to the code is necessary. Otherwise it is not possible with the current version of pandas (Version 1.0 in my case) to convolute a real power curve from the turbine database. 

Removing np.array (row 11 of this code) seems to be enough to fix the problem.

Minimal example code to reproduce the problem:

from reskit import windpower
windpower.convolutePowerCurveByGuassian('N117_Delta')

Hope this can help :)