### PR TITLE
Changed _split_locs function at workflow_manager.py

### DIFF
--- a/reskit/workflow_manager.py
+++ b/reskit/workflow_manager.py
@@ -393,13 +393,27 @@ class WorkflowManager():
             return xds
 
 
+# Original Code
+# def _split_locs(placements, groups):
+#     if groups == 1:
+#         yield placements
+#     else:
+#         locs = gk.LocationSet(placements.index)
+#         for loc_group in locs.splitKMeans(groups=groups):
+#             yield placements.loc[loc_group[:]]
+
+# A new suggestion for _split_locs function
 def _split_locs(placements, groups):
+    from sklearn.cluster import KMeans
     if groups == 1:
         yield placements
     else:
         locs = gk.LocationSet(placements.index)
-        for loc_group in locs.splitKMeans(groups=groups):
-            yield placements.loc[loc_group[:]]
+        obs = np.column_stack([locs.lons,locs.lats])
+        km = KMeans(n_clusters=groups).fit(obs)
+        for i in range(groups):
+            sel = km.labels_ == i
+            yield placements.loc[sel]
 
 
 def distribute_workflow(workflow_function: FunctionType, placements: pd.DataFrame, jobs: int = 2, max_batch_size: int = None, intermediate_output_dir: str = None, **kwargs) -> xarray.Dataset:


### PR DESCRIPTION
Hi.

As i was trying to use the distribute_workflow function to utilize the multiprocessing capabilities of my pc, i stumble upon a small problem. 

If i use the function with a placement dataframe of wind turbines with duplicates on location (lat & lon in my case), i seem to receive a much larger amount of wind turbine. Based on my observation, the duplicates seemed to be duplicated again by the function several times. 

I will try to my best to give you an example here 😃. In this example i have a set of 20 wind turbines in total. I deliberately use only 10 different locations (just random locations) 2 times to explain my point. 

import reskit as rk
import pandas as pd

placement = pd.DataFrame([[6150,110,1,1,'6200M152']]*20,columns=['capacity','hub_height','lon','lat','powerCurve'])
placement[['lat','lon']] = [[54.088,6.416],[55.259,7],[54.124,6.923],[53.213,7.25],[54.161,7.3],
                           [52.295,8.213],[55.1012,6.284],[52.124,7.023],[55.29,7.812],[52.171,7.23]]*2

kwargs = {}
kwargs['placements']= placement
kwargs['merra_path']='Data/2019/'

 **For the first step i use no parallel processing** 

rk.wind.offshore_wind_merra_caglayan2019(**kwargs)

![grafik](https://user-images.githubusercontent.com/63661348/94496560-02c4cf80-01f5-11eb-8e10-86e7ef71e1e6.png)

I use this as my baseline

**For the second step i use the distribute workflow function with the original _split_locs function**

rk.workflow_manager.distribute_workflow(rk.wind.offshore_wind_merra_caglayan2019, **kwargs)

![grafik](https://user-images.githubusercontent.com/63661348/94496631-3273d780-01f5-11eb-8914-7396e6fb034e.png)

As you can see here, i get more than 20 locations. This would then indicate that some turbines are calculated more than once. 


 **For the final step i use the distribute workflow function with the edited _split_locs function**

rk.workflow_manager.distribute_workflow(rk.wind.offshore_wind_merra_caglayan2019, **kwargs)

![grafik](https://user-images.githubusercontent.com/63661348/94496759-91d1e780-01f5-11eb-9687-64ed0618c164.png)

By slightly changing the code i manage to make sure that every turbine is only calculated once regarless the duplicates. 


I know that this use case is not common. I only stumble upon this problem as i am trying to use the wind turbine dataset from Germany's Marktstammdatenregister. A considerable amount of non exact locations (which in some cases are duplicates) can sadly be found there.

I thank you for your attention ! I am also sorry, if this pull request is badly structured and is too long. 

Best regards,
Nicholas
