### PR TITLE
fixed bug if execute_workflow_iteratively is executed twice

### DIFF
--- a/reskit/util/weather_tile.py
+++ b/reskit/util/weather_tile.py
@@ -4,6 +4,7 @@ import geokit as gk
 import osgeo
 import pandas as pd
 from smopy import deg2num
+import numpy as np
 
 
 def get_tile_XY(zoom, lon=None, lat=None, geom=None):
@@ -114,7 +115,10 @@ def get_dataframe_with_weather_tilepaths(placements, weather_path, zoom):
         assert "geom" in placements.columns or all([c in placements.columns for c in ["lon", "lat"]]), (
             f"pd.DataFrame must contain 'geom' or 'lat' and 'lon' columns."
         )
-        assert not "RESKit_sim_order" in placements.columns, f"placements must not have 'RESKit_sim_order' attribute"
+        if "RESKit_sim_order" in placements.columns:
+            assert (placements["RESKit_sim_order"].to_numpy() == np.arange(len(placements))).all(), (
+                "'RESKit_sim_order' must equal range(len(placements))"
+            )
         if not "lon" in placements.columns:
             placements["lon"] = placements.geom.apply(lambda x: x.GetX())
         if not "lat" in placements.columns:
@@ -146,16 +150,18 @@ def get_dataframe_with_weather_tilepaths(placements, weather_path, zoom):
                 axis=1,
             )
     else:
-        # make sure we have no source column to avoid overwriting data
-        assert not "source" in placements.columns, (
-            f"If weather_path is given, placements must not have a 'source' attribute already"
-        )
-
-        # add source column with the actual tile filepaths
-        placements["source"] = placements.apply(
+        # make sure we have either no source column to avoid overwriting data, or it is the correct one already
+        source = placements.apply(
             lambda x: _get_tilepath(weather_path=weather_path, zoom=zoom, lon=x.lon, lat=x.lat),
             axis=1,
         )
+        if "source" in placements.columns:
+            assert (placements["source"] == source).all(), (
+                "If weather_path is given, placements must not have a 'source' attribute already, or it needs to be the same as derived from weather_path"
+            )
+        else:
+            # add source column with the actual tile filepaths
+            placements["source"] = source
 
     # add an id column to ensure correct order preservation
     # placements["RESKit_sim_order"] = range(len(placements)) #TODO remove


### PR DESCRIPTION
fixed bug by checking:
1) if "RESKit_sim_order" is already in placements, it needs to be "correct", i.e. the same as if it would be freshly set
2) if "source" already in placements, it needs to contain the correct tile paths 