### PR TITLE
ci: enable codecov coverage reporting

### DIFF
--- a/.github/workflows/test_push.yml
+++ b/.github/workflows/test_push.yml
@@ -18,3 +18,5 @@ jobs:
       examples_to_execute: "examples/1_load_input_data/1_2_1_reading_merra_weather_data.ipynb examples/1_load_input_data/1_2_2_vertically_project_wind_speed_from_merra.ipynb examples/2_economic/ examples/3_wind examples/4_solar examples/5_geothermal/ examples/6_direct_air_capture/"
       multiprocessing_pytest_string: "-n auto"
       multiprocessing_example_string: "-n 2"
+      coverage: true
+      coverage_package_name: "reskit"

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,10 +2,10 @@ coverage:
   status:
     project:
       default:
-        enabled: false
+        enabled: true
     patch:
       default:
-        enabled: false
+        enabled: true
 
 comment:
   layout: "reach,diff,flags,files"


### PR DESCRIPTION
## Summary
- Enable `coverage` and `coverage_package_name` parameters in the push workflow so pytest-cov collects coverage and uploads it to Codecov
- Enable `project` and `patch` status checks in `codecov.yml` so coverage regressions are visible on PRs

## Prerequisites
- A `CODECOV_TOKEN` repository secret must be configured (required by the reusable workflow for the Codecov upload step)

## Test plan
- [ ] Verify the push workflow runs successfully and uploads coverage to [Codecov](https://app.codecov.io/gh/FZJ-IEK3-VSA/RESKit)
- [ ] Verify Codecov status checks appear on subsequent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)