### PR TITLE
fix small bugs / polish code based on the AI report from phil-fzj

### DIFF
--- a/reskit/util/local_values.py
+++ b/reskit/util/local_values.py
@@ -113,7 +113,7 @@ def distanceToCoastline(latitude, longitude, distancetoCoastFilePath=None):
         Distance in kilometers, or None if the point is out of bounds or an error occurs.
     """
     if distancetoCoastFilePath is None:
-        if not "distancetoCoastFilePath" in DEFAULT_PATHS:
+        if not "distancetoCoastPath" in DEFAULT_PATHS:
             raise KeyError(f"Add 'distancetoCoastFilePath' key with filepath value to default_paths.yaml")
         distancetoCoastFilePath = DEFAULT_PATHS.get("distancetoCoastPath")
         if distancetoCoastFilePath is None:

--- a/reskit/wind/economic/offshore_cost_model.py
+++ b/reskit/wind/economic/offshore_cost_model.py
@@ -2,7 +2,6 @@ import numpy as np
 import warnings
 
 from reskit.parameters.parameters import OffshoreParameters
-from reskit.util.local_values import *
 from reskit.wind.economic.onshore_cost_model import onshore_tcc
 
 

--- a/test/03_wind/economic/test_onshore_cost_model.py
+++ b/test/03_wind/economic/test_onshore_cost_model.py
@@ -12,18 +12,20 @@ def test_onshore_turbine_capex():
         capacity=4200,
         hub_height=120,
         rotor_diam=136,
+        #base_capex=5000*1100,
         base_capacity=5000,
         base_hub_height=130,
         base_rotor_diam=140,
     )
 
-    assert np.isclose(capex / 4200, 1051.809567439314)
+    assert np.isclose(capex / 4200, 913.7163211549489)
 
     caps = np.array([4200, 4100, 4000, 3900])
     capex = onshore_turbine_capex(
         capacity=caps,
         hub_height=[120, 120, 120, 120],
         rotor_diam=[136, 140, 145, 150],
+        #base_capex=5000*1100,
         base_capacity=5000,
         base_hub_height=130,
         base_rotor_diam=140,
@@ -31,4 +33,4 @@ def test_onshore_turbine_capex():
         bos_share=0.15,
     )
 
-    assert np.isclose(capex / caps, [1083.81015125, 1160.05867791, 1255.46018725, 1362.33950513]).all()
+    assert np.isclose(capex / caps, [931.38977592,974.44510595,1029.75686152,1090.17668668]).all()


### PR DESCRIPTION
- Fixed small bugs based on the AI review from phil-fzj.

@phil-fzj 
There seem to be two issues in the current test ("test_onshore_turbine_capex"):

1. The previous expected value in the assertion no longer matched the current implementation after the WISDEM update. I updated it from "1051.809567439314" to "913.7163211549489". Please check again whether this is correct.

2. There seems to be a bug in the scaling tests. They scale against a base turbine with "base_capacity=5000", but still use the default "base_capex" of the default 4200 kW turbine. To make this consistent, we would need to explicitly add to the function: "base_capex = 5000 * 1100" 
 This would define the 5000 kW base turbine with a specific CAPEX of 1100 EUR/kW. With this assumption, the expected value would change from "913.7163211549489" to "1087.757525184463" If this assumption is correct, you can use the two lines that are currently commented out.
