### PR TITLE
fix: adapt interpolateValues calls to stricter geokit API

### DIFF
--- a/requirements-dev.yml
+++ b/requirements-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - numba >=0.55,<=0.65.1
   - scipy >=1.7.2,<=1.14.1
   - scikit-learn >=1.3.0,<=1.7.1
-  - geokit >=1.4.0,<=1.6.0
+  - geokit >=1.4.0,<=1.9.0
   - netcdf4 >=1.5.8,!=1.6.3,<=1.7.4
   - xarray >=0.20.0,<=2026.4.0
   - pvlib-python =0.9.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -14,7 +14,7 @@ dependencies:
   - numba >=0.55,<=0.62.1
   - scipy >=1.7.2,<=1.14.1
   - scikit-learn >=1.3.0,<=1.7.1
-  - geokit >=1.4.0,<=1.6.0
+  - geokit >=1.4.0,<=1.9.0
   - netcdf4 >=1.5.8,!=1.6.3,<=1.7.3
   - xarray >=0.16.0,<=2025.11.0
   - pvlib-python =0.9.0

--- a/reskit/csp/workflows/dataset_handler.py
+++ b/reskit/csp/workflows/dataset_handler.py
@@ -27,9 +27,9 @@ class dataset_handler:
 
         placements["geom"] = placements[["lon", "lat"]].apply(lambda x: gk.geom.point(x[0], x[1], srs=4326), axis=1)
 
-        placements["dni_gsa"] = gk.raster.interpolateValues(source=gsa_dni_path, points=placements.geom) * 1000 / 24
+        placements["dni_gsa"] = gk.raster.interpolateValues(source=gsa_dni_path, points=placements.geom.tolist()) * 1000 / 24
 
-        placements["tamb_gsa"] = gk.raster.interpolateValues(source=gsa_tamb_path, points=placements.geom)
+        placements["tamb_gsa"] = gk.raster.interpolateValues(source=gsa_tamb_path, points=placements.geom.tolist())
 
         mat_HTF_opt = self._get_opt_HTF_matrix()
 

--- a/reskit/csp/workflows/dataset_handler.py
+++ b/reskit/csp/workflows/dataset_handler.py
@@ -27,7 +27,9 @@ class dataset_handler:
 
         placements["geom"] = placements[["lon", "lat"]].apply(lambda x: gk.geom.point(x[0], x[1], srs=4326), axis=1)
 
-        placements["dni_gsa"] = gk.raster.interpolateValues(source=gsa_dni_path, points=placements.geom.tolist()) * 1000 / 24
+        placements["dni_gsa"] = (
+            gk.raster.interpolateValues(source=gsa_dni_path, points=placements.geom.tolist()) * 1000 / 24
+        )
 
         placements["tamb_gsa"] = gk.raster.interpolateValues(source=gsa_tamb_path, points=placements.geom.tolist())
 

--- a/reskit/geothermal/workflows/egs_workflow_manager.py
+++ b/reskit/geothermal/workflows/egs_workflow_manager.py
@@ -142,7 +142,7 @@ class EGS_workflowmanager:
                     # self.__setattr__(name=value)
 
         set_dims(latsGlobal=ds.lat.values, lonsGlobal=ds.lon.values)
-        points = gk.LocationSet(self.placements[["lon", "lat"]].values)
+        points = [tuple(coords) for coords in self.placements[["lon", "lat"]].values]
 
         for var in vars:
             if "depth" in ds.dims:
@@ -201,8 +201,8 @@ class EGS_workflowmanager:
         # self.latsGlobal =  ds.lat.values
         # self.lonsGlobal =  ds.lon.values
 
-        # convert coordinates to a LocationSet for interpolateValues
-        points = gk.LocationSet(self.placements[["lon", "lat"]].values)
+        # convert coordinates to a list of (lon, lat) tuples for interpolateValues
+        points = [tuple(coords) for coords in self.placements[["lon", "lat"]].values]
 
         # get data
         shape = (

--- a/reskit/geothermal/workflows/egs_workflow_manager.py
+++ b/reskit/geothermal/workflows/egs_workflow_manager.py
@@ -142,7 +142,7 @@ class EGS_workflowmanager:
                     # self.__setattr__(name=value)
 
         set_dims(latsGlobal=ds.lat.values, lonsGlobal=ds.lon.values)
-        points = self.placements[["lon", "lat"]].values
+        points = gk.LocationSet(self.placements[["lon", "lat"]].values)
 
         for var in vars:
             if "depth" in ds.dims:
@@ -201,8 +201,8 @@ class EGS_workflowmanager:
         # self.latsGlobal =  ds.lat.values
         # self.lonsGlobal =  ds.lon.values
 
-        # convert coordinates to np.array
-        points = self.placements[["lon", "lat"]].values
+        # convert coordinates to a LocationSet for interpolateValues
+        points = gk.LocationSet(self.placements[["lon", "lat"]].values)
 
         # get data
         shape = (

--- a/reskit/util/topography.py
+++ b/reskit/util/topography.py
@@ -12,7 +12,6 @@ def visibility_from_topography(
     max_degree=0.1,
     degree_step=0.003,
     theta_step=3,
-    _interpolation="cubic",
 ):
     """Determine visibility around a given point based on topography. Also
     gives planar angle, planar elevation, and planar distance of multiple
@@ -107,7 +106,7 @@ def visibility_from_topography(
             sample_lats.flatten(),
         ]
     )
-    elevs = gk.raster.interpolateValues(elevation_raster, locs, interpolate=_interpolation)
+    elevs = gk.raster.interpolateValues(elevation_raster, gk.LocationSet(locs))
     #     elevs = np.full( locs.shape[0], base_elevation-eye_level)
     elevs = elevs.reshape(sample_lons.shape)
 

--- a/reskit/wind/core/logarithmic_profile.py
+++ b/reskit/wind/core/logarithmic_profile.py
@@ -296,6 +296,9 @@ def roughness_from_clc(clc_path, loc, window_range=0):
 
     # Get pixels values from clc
     clcGridValues = gk.raster.interpolateValues(clc_path, loc, winRange=window_range, noDataOkay=True)
+    # interpolateValues returns a scalar for a single location; ensure an array so the
+    # downstream item-assignment/iteration works regardless of the number of locations
+    clcGridValues = np.atleast_1d(clcGridValues)
 
     # make output array
     if window_range > 0:

--- a/reskit/workflow_manager.py
+++ b/reskit/workflow_manager.py
@@ -268,11 +268,13 @@ class WorkflowManager:
                     "points must be a list of (lon, lat) tuples."
                 )
 
-            _lra = gk.raster.interpolateValues(fp, points, mode=spatial_interpolation)
+            # interpolateValues returns a scalar for a single location; ensure a 1-D array
+            # so the nan handling below (and callers) work regardless of the number of points
+            _lra = np.atleast_1d(gk.raster.interpolateValues(fp, points, mode=spatial_interpolation))
             # if getting values fails, it could be because of interpolation method.
             # these values will be replaced with the nearest interpolation method
             if np.isnan(_lra).any():
-                _lra_near = gk.raster.interpolateValues(fp, self.locs, mode="near")
+                _lra_near = np.atleast_1d(gk.raster.interpolateValues(fp, self.locs, mode="near"))
                 _lra[np.isnan(_lra)] = _lra_near[np.isnan(_lra)]
             # still nans, i.e. the cell itself is nan, but maybe its neighbors are not
             # try the (nan)median of the surrounding cells
@@ -283,7 +285,7 @@ class WorkflowManager:
                     return np.nanmedian(vals)
 
                 points = [(loc.lon, loc.lat) for loc in self.locs._locations]
-                _lra_near = gk.raster.interpolateValues(fp, points, mode="func", func=_nanmedian)
+                _lra_near = np.atleast_1d(gk.raster.interpolateValues(fp, points, mode="func", func=_nanmedian))
                 _lra[np.isnan(_lra)] = _lra_near[np.isnan(_lra)]
         return _lra
 


### PR DESCRIPTION
Newer geokit narrows the accepted `points` types for gk.raster.interpolateValues to tuple/ogr.Geometry/Location/list/ LocationSet (numpy arrays and pandas Series are rejected), forwards **kwargs to extractValues in "near" mode, and returns a scalar for a single location. Adapt the reskit call sites accordingly:

- topography: wrap the ndarray points in gk.LocationSet and drop the  dead `_interpolation` parameter (never used in old geokit, and its forwarded `interpolate` kwarg is now rejected by extractValues)
- egs: wrap placement lon/lat ndarray in gk.LocationSet
- csp dataset_handler: pass placements.geom as a list (.tolist()) instead of a pandas Series
- logarithmic_profile: np.atleast_1d on the result so single-location  scalar returns don't break item assignment
- workflow_manager: np.atleast_1d on get_scalar_values_from_raster results so single-location placement groups (e.g. CSP per-dataset splits) return a 1-D array