### PR TITLE
214 enable workflow wind config to skip lra

### DIFF
--- a/reskit/wind/workflows/workflows.py
+++ b/reskit/wind/workflows/workflows.py
@@ -399,8 +399,8 @@ def wind_config(
     placements,
     weather_path,
     weather_source_type,
-    enable_lra_adjustment,
     weather_lra_ws_path,
+    enable_lra_adjustment,
     real_lra_ws_path,
     real_lra_ws_scaling,
     real_lra_ws_spatial_interpolation,
@@ -433,14 +433,14 @@ def wind_config(
         A Dataframe object with the parameters needed by the simulation.
     weather_path : str
         Path to the temporally resolved weather data, e.g. ERA-5 or MERRA-2 etc.
-    enable_lra_adjustment : bool
-        If True, enables the long-run-average adjustment
-        using the provided lra information.
-        Note: If False, all lra related parameters have no effect.
     weather_lra_ws_path : str
         The path to a raster with the corresponding long-run-average
         windspeeds of the actual weather data (will be corrected to the
         real lra if given, else weather_lra_path has no effect)
+    enable_lra_adjustment : bool
+        If True, enables the long-run-average adjustment
+        using the provided lra information.
+        Note: If False, all lra related parameters have no effect.
     real_lra_ws_path : str, float
         Either a float/int (1.0 means no scaling) or a path to a raster
         with real long-run-average wind speeds, e.g. the Global Wind Atlas
@@ -566,6 +566,7 @@ def wind_config(
     assert callable(ws_correction_func), (
         f"ws_correction_func must be an executable with a single argument that can be passed as np.array (if not 1)."
     )
+    assert isinstance(enable_lra_adjustment, bool), "enable_lra_adjustment must be boolean."
 
     wf = WindWorkflowManager(placements)
 
@@ -582,15 +583,15 @@ def wind_config(
         verbose=False,
     )
 
-    wf.adjust_variable_to_long_run_average(
-        variable="elevated_wind_speed",
-        source_long_run_average=weather_lra_ws_path,
-        real_long_run_average=real_lra_ws_path,
-        nodata_fallback=real_lra_ws_nodata_fallback,
-        spatial_interpolation=real_lra_ws_spatial_interpolation,
-        real_lra_scaling=real_lra_ws_scaling,
-        enable_lra_adjustment=enable_lra_adjustment,
-    )
+    if enable_lra_adjustment:
+        wf.adjust_variable_to_long_run_average(
+            variable="elevated_wind_speed",
+            source_long_run_average=weather_lra_ws_path,
+            real_long_run_average=real_lra_ws_path,
+            nodata_fallback=real_lra_ws_nodata_fallback,
+            spatial_interpolation=real_lra_ws_spatial_interpolation,
+            real_lra_scaling=real_lra_ws_scaling,
+        )
 
     if height_scaling_method is not None:
         if isinstance(height_scaling_method, list):

--- a/reskit/wind/workflows/workflows.py
+++ b/reskit/wind/workflows/workflows.py
@@ -399,6 +399,7 @@ def wind_config(
     placements,
     weather_path,
     weather_source_type,
+    enable_lra_adjustment,
     weather_lra_ws_path,
     real_lra_ws_path,
     real_lra_ws_scaling,
@@ -432,6 +433,10 @@ def wind_config(
         A Dataframe object with the parameters needed by the simulation.
     weather_path : str
         Path to the temporally resolved weather data, e.g. ERA-5 or MERRA-2 etc.
+    enable_lra_adjustment : bool
+        If True, enables the long-run-average adjustment
+        using the provided lra information.
+        Note: If False, all lra related parameters have no effect.
     weather_lra_ws_path : str
         The path to a raster with the corresponding long-run-average
         windspeeds of the actual weather data (will be corrected to the
@@ -584,6 +589,7 @@ def wind_config(
         nodata_fallback=real_lra_ws_nodata_fallback,
         spatial_interpolation=real_lra_ws_spatial_interpolation,
         real_lra_scaling=real_lra_ws_scaling,
+        enable_lra_adjustment=enable_lra_adjustment,
     )
 
     if height_scaling_method is not None:

--- a/reskit/workflow_manager.py
+++ b/reskit/workflow_manager.py
@@ -299,7 +299,6 @@ class WorkflowManager:
         nodata_fallback: str = "nan",
         nodata_fallback_scaling: float = 1,
         allow_nans: bool = True,
-        enable_lra_adjustment: bool = True,
     ):
         """Adjusts the average mean of the specified variable to a known long-run-average
 
@@ -358,20 +357,11 @@ class WorkflowManager:
         allow_nans : boolean, optional
             If True, NaN values may remain after scaling, else an error will raised. By default True.
 
-        enable_lra_adjustment : bool, optional
-            If True, enables the long-run-average adjustment
-            using the provided lra information.
-            Note: If False, the entire function is skipped.
-            By default True.
-
         Returns
         -------
         WorkflowManager
             Returns the invoking WorkflowManager (for chaining)
         """
-        # check if adjustment is enabled, else early exit
-        if not enable_lra_adjustment:
-            return self
         # otherwise proceed as usual with the adjustment
         if not (nodata_fallback is None or callable(nodata_fallback) or isinstance(nodata_fallback, (float, int, str))):
             raise TypeError(f"'nodata_fallback' must be a float or a Callable.")

--- a/reskit/workflow_manager.py
+++ b/reskit/workflow_manager.py
@@ -362,7 +362,6 @@ class WorkflowManager:
         WorkflowManager
             Returns the invoking WorkflowManager (for chaining)
         """
-        # otherwise proceed as usual with the adjustment
         if not (nodata_fallback is None or callable(nodata_fallback) or isinstance(nodata_fallback, (float, int, str))):
             raise TypeError(f"'nodata_fallback' must be a float or a Callable.")
 

--- a/reskit/workflow_manager.py
+++ b/reskit/workflow_manager.py
@@ -299,6 +299,7 @@ class WorkflowManager:
         nodata_fallback: str = "nan",
         nodata_fallback_scaling: float = 1,
         allow_nans: bool = True,
+        enable_lra_adjustment: bool = True,
     ):
         """Adjusts the average mean of the specified variable to a known long-run-average
 
@@ -357,11 +358,21 @@ class WorkflowManager:
         allow_nans : boolean, optional
             If True, NaN values may remain after scaling, else an error will raised. By default True.
 
+        enable_lra_adjustment : bool, optional
+            If True, enables the long-run-average adjustment
+            using the provided lra information.
+            Note: If False, the entire function is skipped.
+            By default True.
+
         Returns
         -------
         WorkflowManager
             Returns the invoking WorkflowManager (for chaining)
         """
+        # check if adjustment is enabled, else early exit
+        if not enable_lra_adjustment:
+            return self
+        # otherwise proceed as usual with the adjustment
         if not (nodata_fallback is None or callable(nodata_fallback) or isinstance(nodata_fallback, (float, int, str))):
             raise TypeError(f"'nodata_fallback' must be a float or a Callable.")
 

--- a/test/05_workflows/wind_workflows/test_wind_workflows.py
+++ b/test/05_workflows/wind_workflows/test_wind_workflows.py
@@ -148,6 +148,7 @@ def test_wind_config(pt_wind_placements: pd.DataFrame):
         placements=pt_wind_placements,
         weather_path=TEST_DATA["era5-like"],
         weather_source_type="ERA5",
+        enable_lra_adjustment=True,
         weather_lra_ws_path=rk_weather.Era5Source.LONG_RUN_AVERAGE_WINDSPEED_2008TO2017,
         real_lra_ws_path=TEST_DATA["gwa100-like.tif"],
         real_lra_ws_scaling=1,


### PR DESCRIPTION
This is a minor patch to the wind_config workflow. Now it is able to skip the adjustment using the longterm run average, which is only useful for workflows with a need of further downscaling for the weather data in use.