### PR TITLE
286 update to pandas v3 yields very different outputs

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip <=26.1.2
   - matplotlib <=3.10.5
   - descartes <=1.1.0
-  - pandas >=2.0.0,<=2.3.3
+  - pandas >=2.0.0,<=3.0.3
   - openpyxl <=3.1.5
   - numpy >=1.25.0,<=1.26.4
   - numba >=0.58.1,<=0.65.1

--- a/reskit/csp/workflows/csp_workflow_manager.py
+++ b/reskit/csp/workflows/csp_workflow_manager.py
@@ -392,7 +392,7 @@ class PTRWorkflowManager(SolarWorkflowManager):
             )
 
             self.sim_data["solar_zenith_degree"][:, location_iter] = np.nan_to_num(
-                _solarpos["apparent_zenith"].values, 0
+                _solarpos["apparent_zenith"].to_numpy(copy=True), nan=0
             )
 
             # calculate aoi
@@ -406,9 +406,11 @@ class PTRWorkflowManager(SolarWorkflowManager):
                 gcr=self.ptr_data["SF_density_direct"],
             )  # irrelevant for true-tracking
 
-            self.sim_data["theta"][:, location_iter] = np.nan_to_num(truetracking_angles["aoi"].values, 0)
+            self.sim_data["theta"][:, location_iter] = np.nan_to_num(
+                truetracking_angles["aoi"].to_numpy(copy=True), nan=0
+            )
             self.sim_data["tracking_angle"][:, location_iter] = np.nan_to_num(
-                truetracking_angles["tracker_theta"].values, 0
+                truetracking_angles["tracker_theta"].to_numpy(copy=True), nan=0
             )
 
             # from [1]	KALOGIROU, Soteris A. Environmental Characteristics. In: Soteris Kalogirou, ed. Solar energy engineering. Processes and systems. Waltham, Mass: Academic Press, 2014, pp. 51-123.

--- a/reskit/csp/workflows/dataset_handler.py
+++ b/reskit/csp/workflows/dataset_handler.py
@@ -25,7 +25,9 @@ class dataset_handler:
         assert "lat" in placements.columns
         assert "lon" in placements.columns
 
-        placements["geom"] = placements[["lon", "lat"]].apply(lambda x: gk.geom.point(x[0], x[1], srs=4326), axis=1)
+        placements["geom"] = [
+            gk.geom.point(row.lon, row.lat, srs=4326) for row in placements[["lon", "lat"]].itertuples()
+        ]
 
         placements["dni_gsa"] = (
             gk.raster.interpolateValues(source=gsa_dni_path, points=placements.geom.tolist()) * 1000 / 24
@@ -35,9 +37,10 @@ class dataset_handler:
 
         mat_HTF_opt = self._get_opt_HTF_matrix()
 
-        placements["Dataset_opt"] = placements[["dni_gsa", "tamb_gsa"]].apply(
-            lambda x: self._lookup(x[0], x[1], mat_HTF_opt), axis=1
-        )
+        placements["Dataset_opt"] = [
+            self._lookup(dni, tamb, mat_HTF_opt) for dni, tamb in zip(placements["dni_gsa"], placements["tamb_gsa"])
+        ]
+
         placements = placements.drop(["geom", "dni_gsa", "tamb_gsa"], axis=1)
 
         return placements

--- a/reskit/geothermal/workflows/egs_workflow_manager.py
+++ b/reskit/geothermal/workflows/egs_workflow_manager.py
@@ -788,7 +788,7 @@ class EGS_workflowmanager:
                 # do shapefile
 
                 self.placements["geom"] = [
-                    gk.geom.point(row.lon, row.lat) for row in self.placements[["lon", "lat"]].itertuples
+                    gk.geom.point(row.lon, row.lat) for row in self.placements[["lon", "lat"]].itertuples()
                 ]
 
                 gk.vector.createVector(self.placements, savepath)

--- a/reskit/geothermal/workflows/egs_workflow_manager.py
+++ b/reskit/geothermal/workflows/egs_workflow_manager.py
@@ -786,9 +786,11 @@ class EGS_workflowmanager:
 
             if filetype.lower() == ".shp":
                 # do shapefile
-                self.placements["geom"] = self.placements[["lon", "lat"]].apply(
-                    lambda x: gk.geom.point(x[0], x[1]), axis=1
-                )
+
+                self.placements["geom"] = [
+                    gk.geom.point(row.lon, row.lat) for row in self.placements[["lon", "lat"]].itertuples
+                ]
+
                 gk.vector.createVector(self.placements, savepath)
             elif filetype.lower() == ".nc4":
                 # do netcdf4

--- a/reskit/solar/workflows/solar_workflow_manager.py
+++ b/reskit/solar/workflows/solar_workflow_manager.py
@@ -113,7 +113,7 @@ class SolarWorkflowManager(WorkflowManager):
         """
         self.placements["azimuth"] = 180
 
-        self.placements["azimuth"].values[self.locs.lats < 0] = 0
+        self.placements["azimuth"].to_numpy(copy=True)[self.locs.lats < 0] = 0
         return self
 
     def apply_elevation(self, elev, fallback_elev=0):
@@ -954,7 +954,7 @@ class SolarWorkflowManager(WorkflowManager):
             db = pvlib.pvsystem.retrieve_sam("CECMod")
             original_module = getattr(db, original_module_name)
             # scale module parameters to tech_year
-            module = pd.Series(index=projected_module.index, dtype="float64")
+            module = pd.Series(index=projected_module.index, dtype="object")
             for param, val_proj in zip(projected_module.index, projected_module):
                 if param == "Date":
                     module[param] = str(tech_year)

--- a/reskit/solar/workflows/solar_workflow_manager.py
+++ b/reskit/solar/workflows/solar_workflow_manager.py
@@ -112,8 +112,8 @@ class SolarWorkflowManager(WorkflowManager):
 
         """
         self.placements["azimuth"] = 180
+        self.placements.loc[self.locs.lats < 0, "azimuth"] = 0
 
-        self.placements["azimuth"].to_numpy(copy=True)[self.locs.lats < 0] = 0
         return self
 
     def apply_elevation(self, elev, fallback_elev=0):

--- a/reskit/util/leap_day.py
+++ b/reskit/util/leap_day.py
@@ -24,7 +24,7 @@ def remove_leap_day(timeseries):
         if timeseries.shape[0] == 8760:
             return timeseries
         elif timeseries.shape[0] == 8784:
-            times = pd.date_range("01-01-2000 00:00:00", "12-31-2000 23:00:00", freq="H")
+            times = pd.date_range("01-01-2000 00:00:00", "12-31-2000 23:00:00", freq="h")
             sel = np.logical_and((times.day == 29), (times.month == 2))
             if len(timeseries.shape) == 1:
                 return timeseries[~sel]

--- a/reskit/weather/NCSource.py
+++ b/reskit/weather/NCSource.py
@@ -255,7 +255,7 @@ class NCSource(object):
             assert time_index_from in self.variables.index, (
                 f'ERA_5-key {time_index_from} not known. Check variable "time_index_from" and folder {source}'
             )
-            self.variables["path"][time_name] = self.variables["path"][time_index_from]
+            self.variables.loc[time_name, "path"] = self.variables.loc[time_index_from, "path"]
 
         # set basic variables
         ds = nc.Dataset(self.variables["path"][lat_name], keepweakref=True)

--- a/reskit/workflow_manager.py
+++ b/reskit/workflow_manager.py
@@ -16,6 +16,7 @@ import geokit as gk
 import numpy as np
 import pandas as pd
 import xarray
+from pandas.api.types import is_numeric_dtype
 
 from reskit import weather as rk_weather
 
@@ -632,23 +633,20 @@ class WorkflowManager:
         # write placements
         for c in self.placements.columns:
             # check if c in requestet output_variables
-            if output_variables is not None:
-                if c not in output_variables:
+            if output_variables is not None and c not in output_variables:
+                continue
+
+            column = self.placements[c]
+
+            if not is_numeric_dtype(column):
+                if not all(isinstance(x, (str, bytearray)) for x in column):
                     continue
-            if np.issubdtype(self.placements[c].dtype, np.number):
-                write = True
-            else:
-                write = True
-                for element in self.placements[c]:
-                    if not isinstance(element, (str, bytearray)):
-                        write = False
-                        break
-            if write:
-                xds[c] = xarray.DataArray(
-                    self.placements[c],
-                    dims=["location"],
-                    coords=dict(location=location_coords),
-                )
+
+            xds[c] = xarray.DataArray(
+                column.to_numpy(),
+                dims=["location"],
+                coords=dict(location=location_coords),
+            )
 
         # write sim_data
         for key in self.sim_data.keys():

--- a/test/01_util/util/test_leap_day.py
+++ b/test/01_util/util/test_leap_day.py
@@ -19,7 +19,7 @@ def test_remove_leap_day():
     # Test pandas Series
     series_8784 = pd.Series(
         array_8784,
-        index=pd.date_range("01-01-2000 00:00:00", "31-12-2000 23:00:00", freq="H"),
+        index=pd.date_range("01-01-2000 00:00:00", "31-12-2000 23:00:00", freq="h"),
     )
 
     fixed_array = remove_leap_day(series_8784)

--- a/test/02_weather_source/test_Era5ZarrSource.py
+++ b/test/02_weather_source/test_Era5ZarrSource.py
@@ -203,8 +203,8 @@ def test_Era5ZarrSource_marks_derived_variables(pt_Era5ZarrSource):
 
     assert variables.loc["ssrd_t_adj", "derived_from"] == "ssrd"
     assert variables.loc["fdir_t_adj", "derived_from"] == "fdir"
-    assert variables.loc["ssrd", "derived_from"] is None
-    assert variables.loc["sp", "derived_from"] is None
+    assert pd.isna(variables.loc["ssrd", "derived_from"])
+    assert pd.isna(variables.loc["sp", "derived_from"])
 
 
 def test_Era5ZarrSource_warns_on_nan_first_timestep(pt_Era5ZarrSource):

--- a/test/05_workflows/csp_workflows/test_csp_worklfow_manager.py
+++ b/test/05_workflows/csp_workflows/test_csp_worklfow_manager.py
@@ -328,7 +328,7 @@ def pt_PTRWorkflowManager_solarpos() -> PTRWorkflowManager:
     wfm = test_PTRWorkflowManager__init__()
     wfm.placements["azimuth"] = [90, 180, 180]
     wfm.placements["elev"] = [90, 180, 180]
-    wfm.time_index = pd.date_range("2014-12-31 23:30:00", periods=100, freq="H")
+    wfm.time_index = pd.date_range("2014-12-31 23:30:00", periods=100, freq="h")
     wfm.get_timesteps()
     wfm.ptr_data = pd.Series()
     wfm.ptr_data["SF_density_direct"] = 0.383
@@ -516,7 +516,7 @@ def pt_PTRWorkflowManager_IAM() -> PTRWorkflowManager:
     wfm = test_PTRWorkflowManager__init__()
     wfm.placements["azimuth"] = [90, 180, 180]
     wfm.placements["elev"] = [90, 180, 180]
-    wfm.time_index = pd.date_range("2014-12-31 23:30:00", periods=100, freq="H")
+    wfm.time_index = pd.date_range("2014-12-31 23:30:00", periods=100, freq="h")
     wfm.get_timesteps()
     wfm.sim_data["ptr_data"] = pd.Series()
     wfm.sim_data["ptr_data"]["SF_density_direct"] = 0.383
@@ -968,7 +968,7 @@ def pt_PTRWorkflowManager_economicsSF() -> PTRWorkflowManager:
     wfm.placements["aperture_area_m2"] = 1e5
     wfm.placements["land_area_m2"] = 1e5 / 0.3
 
-    wfm._time_index_ = pd.date_range("2014-12-31 23:30:00", periods=100, freq="H")
+    wfm._time_index_ = pd.date_range("2014-12-31 23:30:00", periods=100, freq="h")
 
     return wfm
 
@@ -1017,7 +1017,7 @@ def pt_PTRWorkflowManager_optplant(
     # wfm.placements['aperture_area_m2'] = 1E5
     # wfm.placements['land_area_m2'] = 1E5 / 0.3
 
-    wfm.time_index = pd.date_range("2015-01-01 00:30:00", periods=8760, freq="H")
+    wfm.time_index = pd.date_range("2015-01-01 00:30:00", periods=8760, freq="h")
 
     return wfm
 
@@ -1070,7 +1070,7 @@ def pt_PTRWorkflowManager_calcElecOut() -> PTRWorkflowManager:
     wfm.ptr_data["storage_efficiency_1"] = 0.99
     wfm.ptr_data["eta_powerplant_1"] = 0.4
 
-    wfm._time_index_ = pd.date_range("2014-12-31 23:30:00", periods=8760, freq="H")
+    wfm._time_index_ = pd.date_range("2014-12-31 23:30:00", periods=8760, freq="h")
 
     return wfm
 


### PR DESCRIPTION
Resolves issue #286. Updating to pandas v3 does change the number of warnings in testing. However, it seems that this is not related to pandas directly but to different warnings filtering. Using '-W always' as pytest option does result in identical numbers of warnings.

The changes:
- changing the pd.Series creation to dtype="object", which was earlier done as a silent upcast
- removing positional indexing in lambda functions, as positional indexing of pd.Series is now deprecated and introducing list comprehension-based solutions that could potentially be faster
- chained assignment is no longer supported, e.g. self.variables["path"][time_name] = self.variables["path"][time_index_from]. This did however just cause a warning and not a test failure.
- numpy objects created with .values will in some cases be read-only due to the copy-on-write principles implemented in pandas 3. This could be solved through the .to_numpy() function or through a .loc implementation.
- changing freq="H" to freq="h" as the former is now deprecated
- a check using np.issubdtype did no longer work as pandas introduced own dtypes. I introduced the pandas-based is_numeric_dtype instead.
- asserts with "is None" were failing because pandas now resorts to nan != None. I changed the assert to pd.isna()