### PR TITLE
Fail the suite on upstream deprecations that RESKit triggers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,24 @@ markers = [
   "notebooks: executes an example notebook with papermill. Deselected by default, run with `pytest -m notebooks`.",
 ]
 addopts = "-m 'not notebooks'" # The notebook tests need several minutes
+# Selective warning gate.
+# A deprecation which RESKit code triggers must fail the suite. An upstream
+# removal is then repaired before it reaches a release. Every other warning stays
+# a warning: third-party noise which RESKit does not cause, and the deprecations
+# which RESKit raises for its own users.
+# Add one entry for each upstream removal and name the upstream version.
+# test/08_dependencies/test_no_deprecated_apis.py covers the RESKit lines which no
+# test executes, because a filter only sees a line which runs.
+filterwarnings = [
+  # pvlib 0.13.1 renamed singleaxis(apparent_azimuth=) to solar_azimuth.
+  "error::pvlib._deprecation.pvlibDeprecationWarning",
+  # xarray deprecates Dataset.drop() for Dataset.drop_vars().
+  "error:dropping variables using `drop` is deprecated:FutureWarning",
+  # xarray changes the merge default from join="outer" to join="exact".
+  "error:In a future version of xarray the default value for join will change:FutureWarning",
+  # Python 3.13 removes logging.warn.
+  "error:The 'warn' function is deprecated:DeprecationWarning",
+]
 
 [tool.codespell]
 ignore-words-list = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ filterwarnings = [
   "error:In a future version of xarray the default value for join will change:FutureWarning",
   # Python 3.13 removes logging.warn.
   "error:The 'warn' function is deprecated:DeprecationWarning",
+  # pytest makes a test which returns a value an error. A test must assert instead.
+  "error::pytest.PytestReturnNotNoneWarning",
 ]
 
 [tool.codespell]

--- a/test/05_workflows/csp_workflows/test_csp_worklfow_manager.py
+++ b/test/05_workflows/csp_workflows/test_csp_worklfow_manager.py
@@ -139,7 +139,7 @@ def print_testresults(variable):
 ####################################
 #####       TEST Init         ######
 ####################################
-def test_PTRWorkflowManager__init__() -> PTRWorkflowManager:
+def _make_PTRWorkflowManager() -> PTRWorkflowManager:
     placements = pd.DataFrame()
     placements["lon"] = [6.083, 6.083, 5.583]  # Longitude
     placements["lat"] = [
@@ -162,12 +162,17 @@ def test_PTRWorkflowManager__init__() -> PTRWorkflowManager:
     return wfm
 
 
+def test_PTRWorkflowManager__init__():
+    """Run _make_PTRWorkflowManager(), which other tests use as a factory."""
+    _make_PTRWorkflowManager()
+
+
 ####################################
 #####  TEST data loading      ######
 ####################################
 @pytest.fixture
 def pt_PTRWorkflowManager_initialized() -> PTRWorkflowManager:
-    return test_PTRWorkflowManager__init__()
+    return _make_PTRWorkflowManager()
 
 
 # load ptr data
@@ -325,7 +330,7 @@ def test_get_timesteps(pt_PTRWorkflowManager_loaded):
 
 @pytest.fixture
 def pt_PTRWorkflowManager_solarpos() -> PTRWorkflowManager:
-    wfm = test_PTRWorkflowManager__init__()
+    wfm = _make_PTRWorkflowManager()
     wfm.placements["azimuth"] = [90, 180, 180]
     wfm.placements["elev"] = [90, 180, 180]
     wfm.time_index = pd.date_range("2014-12-31 23:30:00", periods=100, freq="h")
@@ -513,7 +518,7 @@ def test_calculateCosineLossesParabolicTrough(pt_PTRWorkflowManager_DNI):
 
 @pytest.fixture
 def pt_PTRWorkflowManager_IAM() -> PTRWorkflowManager:
-    wfm = test_PTRWorkflowManager__init__()
+    wfm = _make_PTRWorkflowManager()
     wfm.placements["azimuth"] = [90, 180, 180]
     wfm.placements["elev"] = [90, 180, 180]
     wfm.time_index = pd.date_range("2014-12-31 23:30:00", periods=100, freq="h")
@@ -542,7 +547,7 @@ def test_calculateIAM(pt_PTRWorkflowManager_IAM):
 
 @pytest.fixture
 def pt_PTRWorkflowManager_Shadow() -> PTRWorkflowManager:
-    wfm = test_PTRWorkflowManager__init__()
+    wfm = _make_PTRWorkflowManager()
     wfm.sim_data["tracking_angle"] = tracking_angle_test
     wfm.sim_data["solar_zenith_degree"] = zenith_test
     return wfm
@@ -828,7 +833,7 @@ def test_get_totex(pt_PTRWorkflowManager_initialized):
 
 @pytest.fixture
 def pt_PTRWorkflowManager_economics() -> PTRWorkflowManager:
-    wfm = test_PTRWorkflowManager__init__()
+    wfm = _make_PTRWorkflowManager()
 
     wfm.placements["aperture_area_m2"] = [3e5, 6e5, 3e5]
     wfm.placements["land_area_m2"] = [1e6, 2e6, 1e6]
@@ -896,7 +901,7 @@ def test_get_totex_from_self(pt_PTRWorkflowManager_economics):
 
 @pytest.fixture
 def pt_PTRWorkflowManager_parasitics() -> PTRWorkflowManager:
-    wfm = test_PTRWorkflowManager__init__()
+    wfm = _make_PTRWorkflowManager()
     wfm.ptr_data = {}
     wfm.ptr_data["eta_powerplant_1"] = 0.5
     wfm.placements["capacity_sf_W_th"] = 58e6
@@ -961,7 +966,7 @@ def test_calculateParasitics(pt_PTRWorkflowManager_parasitics):
 
 @pytest.fixture
 def pt_PTRWorkflowManager_economicsSF() -> PTRWorkflowManager:
-    wfm = test_PTRWorkflowManager__init__()
+    wfm = _make_PTRWorkflowManager()
     wfm.ptr_data = {}
     wfm.sim_data["HeattoPlant_W"] = dni_test * 1e5 * 0.7
     wfm.sim_data["Parasitics_solarfield_W_el"] = dni_test * 1e5 * 0.76 * 0.1
@@ -1055,7 +1060,7 @@ def test_optimize_plant_size(pt_PTRWorkflowManager_optplant):
 
 @pytest.fixture
 def pt_PTRWorkflowManager_calcElecOut() -> PTRWorkflowManager:
-    wfm = test_PTRWorkflowManager__init__()
+    wfm = _make_PTRWorkflowManager()
 
     dni = np.tile(dni_test, [63, 1])[0:8760, :]
     wfm.sim_data["HeattoPlant_W"] = dni * 1e5 * 0.7
@@ -1145,7 +1150,7 @@ def test_calculate_LCOE(pt_PTRWorkflowManager_calcLCOE):
 
 @pytest.fixture
 def pt_PTRWorkflowManager_calcCFs() -> PTRWorkflowManager:
-    wfm = test_PTRWorkflowManager__init__()
+    wfm = _make_PTRWorkflowManager()
     wfm.placements["capacity_sf_W_th"] = 58e6
     wfm.sim_data["HeattoPlant_W"] = dni_test * 1e5 * 0.7
     wfm.placements["power_plant_capacity_W_el"] = 58e6 / 2 * 0.4

--- a/test/05_workflows/solar_workflows/test_solar_workflow_manager.py
+++ b/test/05_workflows/solar_workflows/test_solar_workflow_manager.py
@@ -14,7 +14,7 @@ def print_testresults(variable):
     print("max: ", variable[0:140, :].max())
 
 
-def test_SolarWorkflowManager___init__() -> SolarWorkflowManager:
+def _make_SolarWorkflowManager() -> SolarWorkflowManager:
     # (self, placements):
     placements = pd.DataFrame()
     placements["lon"] = [
@@ -63,9 +63,14 @@ def test_SolarWorkflowManager___init__() -> SolarWorkflowManager:
     return man
 
 
+def test_SolarWorkflowManager___init__():
+    """Run _make_SolarWorkflowManager(), which other tests use as a factory."""
+    _make_SolarWorkflowManager()
+
+
 @pytest.fixture
 def pt_SolarWorkflowManager_initialized() -> SolarWorkflowManager:
-    return test_SolarWorkflowManager___init__()
+    return _make_SolarWorkflowManager()
 
 
 def test_SolarWorkflowManager_estimate_tilt_from_latitude(
@@ -195,8 +200,6 @@ def test_SolarWorkflowManager_apply_elevation(pt_SolarWorkflowManager_initialize
         ],  # the last must be equal to fallback since outside raster
     ).all()
 
-    return man
-
 
 @pytest.fixture
 def pt_SolarWorkflowManager_loaded(
@@ -247,8 +250,6 @@ def test_SolarWorkflowManager_determine_solar_position(
     assert np.isclose(man.sim_data["apparent_solar_zenith"].min(), 72.98977919840057)
     assert np.isclose(man.sim_data["apparent_solar_zenith"].max(), 152.49005970814673)
 
-    return man
-
 
 @pytest.fixture
 def pt_SolarWorkflowManager_solpos(
@@ -287,8 +288,6 @@ def test_SolarWorkflowManager_filter_positive_solar_elevation(
     assert np.isclose(man.sim_data["apparent_solar_zenith"].min(), 72.98977919840057)
     assert np.isclose(man.sim_data["apparent_solar_zenith"].max(), 91.89378124249767)
 
-    return man
-
 
 def test_SolarWorkflowManager_determine_extra_terrestrial_irradiance(
     pt_SolarWorkflowManager_solpos: SolarWorkflowManager,
@@ -304,8 +303,6 @@ def test_SolarWorkflowManager_determine_extra_terrestrial_irradiance(
     assert np.isclose(man.sim_data["extra_terrestrial_irradiance"].min(), 1413.940576307916)
     assert np.isclose(man.sim_data["extra_terrestrial_irradiance"].max(), 1414.0192010311885)
 
-    return man
-
 
 def test_SolarWorkflowManager_determine_air_mass(
     pt_SolarWorkflowManager_solpos: SolarWorkflowManager,
@@ -320,8 +317,6 @@ def test_SolarWorkflowManager_determine_air_mass(
     assert np.isclose(man.sim_data["air_mass"].std(), 10.849130623014739)
     assert np.isclose(man.sim_data["air_mass"].min(), 3.383950740640421)
     assert np.isclose(man.sim_data["air_mass"].max(), 29.0)
-
-    return man
 
 
 @pytest.fixture
@@ -706,5 +701,3 @@ def test_SolarWorkflowManager_nan_values_tilt_azimuth_elev___init__() -> SolarWo
     assert ~man.placements["tilt"].isna().any()
     assert ~man.placements["azimuth"].isna().any()
     assert ~man.placements["elev"].isna().any()
-
-    return man

--- a/test/05_workflows/test_workflow_manager.py
+++ b/test/05_workflows/test_workflow_manager.py
@@ -25,7 +25,7 @@ def pt_wind_placements() -> pd.DataFrame:
     return df
 
 
-def test_WorkflowManager___init__():
+def _make_WorkflowManager():
     placements = pd.DataFrame()
     placements["lon"] = [
         6.083,
@@ -72,9 +72,14 @@ def test_WorkflowManager___init__():
     return man
 
 
+def test_WorkflowManager___init__():
+    """Run _make_WorkflowManager(), which other tests use as a factory."""
+    _make_WorkflowManager()
+
+
 @pytest.fixture
 def pt_WorkflowManager_initialized() -> WorkflowManager:
-    return test_WorkflowManager___init__()
+    return _make_WorkflowManager()
 
 
 def test_WorkflowManager_set_time_index(

--- a/test/05_workflows/wind_workflows/test_wind_workflow_manager.py
+++ b/test/05_workflows/wind_workflows/test_wind_workflow_manager.py
@@ -14,7 +14,7 @@ alternative_wind_speed_rasters = {
 }
 
 
-def test_WindWorkflowManager___init__():
+def _make_WindWorkflowManager():
     placements = pd.DataFrame()
     placements["lon"] = [
         6.083,
@@ -68,8 +68,13 @@ def test_WindWorkflowManager___init__():
     return man
 
 
-def test_WindWorkflowManager_with_ws___init__():
-    man = test_WindWorkflowManager___init__()
+def test_WindWorkflowManager___init__():
+    """Run _make_WindWorkflowManager(), which other tests use as a factory."""
+    _make_WindWorkflowManager()
+
+
+def _make_WindWorkflowManager_with_ws():
+    man = _make_WindWorkflowManager()
     # generate random wind data for only 24 hrs and add to manager
     np.random.seed(seed=12345)
     wind_speeds = np.random.randint(0, 16, size=(24, len(man.placements)))
@@ -79,9 +84,14 @@ def test_WindWorkflowManager_with_ws___init__():
     return man
 
 
+def test_WindWorkflowManager_with_ws___init__():
+    """Run _make_WindWorkflowManager_with_ws(), which other tests use as a factory."""
+    _make_WindWorkflowManager_with_ws()
+
+
 @pytest.fixture
 def pt_WindWorkflowManager_initialized() -> WindWorkflowManager:
-    return test_WindWorkflowManager___init__()
+    return _make_WindWorkflowManager()
 
 
 def test_WindWorkflowManager_set_roughness(pt_WindWorkflowManager_initialized):
@@ -206,7 +216,7 @@ def test_WindWorkflowManager_convolute_power_curves(pt_WindWorkflowManager_initi
 
 def test_WindWorkflowManager_apply_wake_correction_of_wind_speeds():
     # first without any "wake_curve"
-    man = test_WindWorkflowManager_with_ws___init__()
+    man = _make_WindWorkflowManager_with_ws()
     assert not "wake_curve" in man.placements.columns
     man.apply_wake_correction_of_wind_speeds(wake_curve=None)
 
@@ -216,7 +226,7 @@ def test_WindWorkflowManager_apply_wake_correction_of_wind_speeds():
     ).all()
 
     # now with scalar "wake_curve" function arg
-    man = test_WindWorkflowManager_with_ws___init__()
+    man = _make_WindWorkflowManager_with_ws()
     assert not "wake_curve" in man.placements.columns
     man.apply_wake_correction_of_wind_speeds(wake_curve="dena_mean")
 
@@ -226,7 +236,7 @@ def test_WindWorkflowManager_apply_wake_correction_of_wind_speeds():
     ).all()
 
     # and last with location-specific column value
-    man = test_WindWorkflowManager_with_ws___init__()
+    man = _make_WindWorkflowManager_with_ws()
     man.placements["wake_curve"] = None
     man.placements.loc[2, "wake_curve"] = "dena_mean"
     man.apply_wake_correction_of_wind_speeds(wake_curve=None)
@@ -321,8 +331,6 @@ def test_WindWorkflowManager_mixed_values___init___():
     assert (man.placements["capacity"] == placements["capacity"]).all()
     assert (man.placements["rotor_diam"] == placements["rotor_diam"]).all()
     assert (man.placements["powerCurve"] == ["SPC:138,25", "SPC:207,25", "SPC:275,25", "V117-3300", "SPC:413,25"]).all()
-
-    return man
 
 
 @pytest.mark.parametrize("max_batch_size", [0, -1, -10])

--- a/test/08_dependencies/test_no_deprecated_apis.py
+++ b/test/08_dependencies/test_no_deprecated_apis.py
@@ -4,12 +4,19 @@ The runtime gate in ``pyproject.toml`` turns such a deprecation warning into an
 error. That gate only sees a line which a test executes. The tests here read the
 RESKit source instead, so they also cover the lines which no test executes.
 
+A guard which removes a keyword makes RESKit give that argument by position. A
+position holds only while the upstream signature holds, so each such guard needs a
+second guard on the upstream signature.
+
 Add a guard here when an upstream project announces a removal which RESKit code
 touches. Record the upstream version in the docstring of the guard.
 """
 
 import ast
+import inspect
 from pathlib import Path
+
+import pvlib
 
 import reskit
 
@@ -53,3 +60,33 @@ def test_no_call_uses_the_pvlib_apparent_azimuth_keyword():
         "These calls use the pvlib keyword 'apparent_azimuth', which pvlib removes soon. "
         "Give the argument by position instead: " + ", ".join(offenders)
     )
+
+
+def test_pvlib_keeps_the_azimuth_of_singleaxis_in_the_second_position():
+    """The positional call of ``singleaxis()`` needs the pvlib argument order.
+
+    pvlib renamed ``apparent_azimuth`` to ``solar_azimuth`` in 0.13.1 and kept the
+    position. This guard holds pvlib to that position. A new parameter before the
+    azimuth, or a move of the azimuth, shifts the arguments of RESKit. The zenith
+    and the azimuth are both angles in degrees, so such a shift gives wrong results
+    without an error.
+    """
+    parameters = list(inspect.signature(pvlib.tracking.singleaxis).parameters.values())
+    positional = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+
+    found = [f"{parameter.name} ({parameter.kind.description})" for parameter in parameters[:2]]
+    message = (
+        "RESKit gives the first two arguments of pvlib.tracking.singleaxis() by position. "
+        f"pvlib {pvlib.__version__} starts the signature with: {', '.join(found)}."
+    )
+
+    assert len(parameters) >= 2, message
+    zenith, azimuth = parameters[0], parameters[1]
+
+    assert zenith.name == "apparent_zenith", message
+    assert azimuth.name in ("apparent_azimuth", "solar_azimuth"), message
+    assert zenith.kind in positional, message
+    assert azimuth.kind in positional, message

--- a/test/08_dependencies/test_no_deprecated_apis.py
+++ b/test/08_dependencies/test_no_deprecated_apis.py
@@ -1,0 +1,55 @@
+"""Guards against third-party APIs which the upstream project announced for removal.
+
+The runtime gate in ``pyproject.toml`` turns such a deprecation warning into an
+error. That gate only sees a line which a test executes. The tests here read the
+RESKit source instead, so they also cover the lines which no test executes.
+
+Add a guard here when an upstream project announces a removal which RESKit code
+touches. Record the upstream version in the docstring of the guard.
+"""
+
+import ast
+from pathlib import Path
+
+import reskit
+
+RESKIT_ROOT = Path(reskit.__file__).parent
+
+
+def _source_files():
+    """All python files of the RESKit package."""
+    return sorted(RESKIT_ROOT.rglob("*.py"))
+
+
+def _calls_with_keyword(path, keyword):
+    """Report every call in ``path`` which gives ``keyword`` as a keyword argument.
+
+    The check reads the syntax tree, not the text. A comment or a string with the
+    same name does not count.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return sorted(
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        for argument in node.keywords
+        if argument.arg == keyword
+    )
+
+
+def test_no_call_uses_the_pvlib_apparent_azimuth_keyword():
+    """The pvlib project renamed ``apparent_azimuth`` to ``solar_azimuth`` in 0.13.1.
+
+    pvlib removes the old name soon. The parameter keeps its position in both
+    names, so RESKit gives the argument by position. A position works on every
+    pvlib version which ``requirements.yml`` supports.
+    """
+    offenders = [
+        f"{path.relative_to(RESKIT_ROOT.parent)}:{line}"
+        for path in _source_files()
+        for line in _calls_with_keyword(path, "apparent_azimuth")
+    ]
+    assert offenders == [], (
+        "These calls use the pvlib keyword 'apparent_azimuth', which pvlib removes soon. "
+        "Give the argument by position instead: " + ", ".join(offenders)
+    )


### PR DESCRIPTION
## Base

This branch targets `maintenance/quick-wins-and-bugs`, not `dev`. That branch contains the code
fixes which the gate below protects, so the gate can only be green on top of it. Merge that
branch first.

## Problem

Several upstream projects announced removals which RESKit code triggers. The fixes were made,
but nothing stopped the next one from appearing: the suite was green with 12 warnings of this
kind, and no CI job promoted them to errors.

## Change 1 — a selective warning gate

`filterwarnings` in `[tool.pytest.ini_options]` of `pyproject.toml`. Every CI job runs pytest and
therefore reads it, so no workflow file changes.

The gate names five warnings and turns only those into errors:

| Warning | Upstream change |
|---|---|
| `pvlibDeprecationWarning` | pvlib 0.13.1 renamed `singleaxis(apparent_azimuth=)` to `solar_azimuth` |
| xarray `drop` FutureWarning | `Dataset.drop()` is replaced by `Dataset.drop_vars()` |
| xarray `join` FutureWarning | the merge default changes from `join="outer"` to `join="exact"` |
| `logging.warn` DeprecationWarning | Python 3.13 removes the name |
| `PytestReturnNotNoneWarning` | pytest will make a returning test an error |

Everything else stays a warning on purpose. Third-party noise is not ours to repair, and RESKit
raises its own deprecations for its own users; a blanket `error` would fail the suite on both.

A filter only sees a line which a test executes, and the suite executes only one of the four
pvlib call sites. `test/08_dependencies/test_no_deprecated_apis.py` therefore reads the syntax
tree of every RESKit module and rejects the removed pvlib keyword. Add a guard there for each
further removal the suite cannot reach.

## Change 2 — twelve tests returned a value

pytest answers a test which returns a value with `PytestReturnNotNoneWarning`. The cause here is
a factory which carries a test name: five of the twelve build a workflow manager, assert its
state and return it, and other tests call them to get that manager. Seven more returned a manager
which no caller read.

Each of the five keeps its body under a `_make_` name, and a test of the old name calls it. The
assertions stay in the test report and the test count does not change. The seven dead returns are
removed.

## Verification

Each gate entry was checked by restoring the file from before its fix and running the tests which
touch it:

| Restored file | Result |
|---|---|
| `csp_workflow_manager.py` | pvlib and `logging.warn` errors — 3 failed, 2 errors |
| `csp/workflows/workflows.py` | `drop` error — 1 failed |
| `util/create_LRA.py` | `join` error — 7 failed |
| `test_wind_workflow_manager.py` | return-not-none error on both wind factories |

Suite: 387 passed, 3 skipped. Base branch on the same day: 386 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
