### PR TITLE
Import the NCSource class explicitly in every weather source

### DIFF
--- a/reskit/weather/Era5Source/Era5Source.py
+++ b/reskit/weather/Era5Source/Era5Source.py
@@ -2,7 +2,7 @@ from os.path import dirname, join
 
 import numpy as np
 
-from .. import NCSource
+from ..NCSource import NCSource
 
 
 class Era5Source(NCSource):

--- a/reskit/weather/GSA_mean/GSAmeanSource.py
+++ b/reskit/weather/GSA_mean/GSAmeanSource.py
@@ -1,6 +1,6 @@
 from os.path import dirname, join
 
-from .. import NCSource
+from ..NCSource import NCSource
 
 
 class GSAmeanSource:

--- a/reskit/weather/GWA_mean/GWAmeanSource.py
+++ b/reskit/weather/GWA_mean/GWAmeanSource.py
@@ -1,6 +1,6 @@
 from os.path import dirname, join
 
-from .. import NCSource
+from ..NCSource import NCSource
 
 
 class GWAmeanSource:

--- a/reskit/weather/IconlamSource/IconlamSource.py
+++ b/reskit/weather/IconlamSource/IconlamSource.py
@@ -2,7 +2,7 @@ from os.path import dirname, join
 
 import numpy as np
 
-from .. import NCSource
+from ..NCSource import NCSource
 
 
 class IconlamSource(NCSource):

--- a/reskit/weather/MerraSource/MerraSource.py
+++ b/reskit/weather/MerraSource/MerraSource.py
@@ -3,7 +3,7 @@ from os.path import dirname, join
 import geokit as gk
 import numpy as np
 
-from .. import NCSource
+from ..NCSource import NCSource
 
 
 class MerraSource(NCSource):

--- a/reskit/weather/SarahSource.py
+++ b/reskit/weather/SarahSource.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from . import NCSource
+from .NCSource import NCSource
 
 
 class SarahSource(NCSource):


### PR DESCRIPTION
Makes the weather sources independent of the import order in `reskit/weather/__init__.py`. One line in each of six files.

This is a prerequisite for enabling ruff's isort rule (`"I"`), which is **not** part of this PR — that reordering is kept separate so this fix can be reviewed on its own.

## The problem

`reskit/weather/__init__.py` re-exports the `NCSource` **class** under the same name as the `NCSource` **module**:

```python
from .NCSource import NCSource   # rebinds the package attribute: module -> class
```

The weather sources reached the class through the package:

```python
from .. import NCSource          # Era5Source, MerraSource, IconlamSource, GSA/GWA
from . import NCSource           # SarahSource
```

`from .. import X` first looks for an attribute `X` on the partially initialised `reskit.weather` package. If it is not there yet, Python falls back to importing the **submodule** and binds that instead — silently, with no error at the import line itself.

Today the fallback never triggers only because `from .NCSource import NCSource` happens to be listed above the source imports. Nothing enforces that, and nothing documents it. Any reordering of `__init__.py` — alphabetising it, adding a source, or letting a formatter touch it — flips the binding to the module and every class body that uses it fails:

```python
loc_to_index = NCSource._loc_to_index_rect(0.25, 0.25)
```

```
AttributeError: module 'reskit.weather.NCSource' has no attribute '_loc_to_index_rect'
```

Because `reskit/__init__.py` pulls in `weather` transitively, this takes down `import reskit` entirely, so every test errors during collection rather than failing individually. Running `ruff check --select I --fix` produces exactly this: 314 collection errors.

## The change

Import the class from the module that defines it:

```python
-from .. import NCSource
+from ..NCSource import NCSource
```

Applied to `Era5Source`, `MerraSource`, `IconlamSource`, `SarahSource`, `GSAmeanSource` and `GWAmeanSource`. The last two never used the name, but were left consistent so the pattern does not get copied back in.

`Era5ZarrSource` already imported it this way — it was the only source that survived the reordering, which is a decent argument that the explicit form is the one to standardise on.

## Why the name is ambiguous in the first place

The root cause is that the module and the class share a name. PEP 8 asks for `lower_case` module names, which would make the collision impossible, but #226 deliberately scoped the naming work to classes, functions and methods, so modules and packages keep their CamelCase spelling.

A scan of the installed package finds 13 places where a package attribute shadows a submodule of the same name:

| package | shadowed submodule | bound to |
| --- | --- | --- |
| `reskit.util` | `create_LRA` | function |
| `reskit.weather` | `Era5Source`, `IconlamSource`, `MerraSource`, `NCSource`, `SarahSource` | class |
| `reskit.weather.CosmoSource` | `CosmoSource` | class |
| `reskit.weather.Era5Source` | `Era5Source`, `Era5ZarrSource` | class |
| `reskit.weather.GSA_mean` | `GSAmeanSource` | class |
| `reskit.weather.GWA_mean` | `GWAmeanSource` | class |
| `reskit.weather.IconlamSource` | `IconlamSource` | class |
| `reskit.weather.MerraSource` | `MerraSource` | class |

Each is a latent version of the same trap. This PR removes the six that are actually reached through the ambiguous form; the rest are only reachable via explicit module paths today. Renaming the modules to `lower_case` would remove the ambiguity at its source, but that is a separate, larger change.

## Verification

Environment `reskit_env_09_2026`, full suite: **479 passed, 3 skipped, 2 failed**.

The two failures are pre-existing and unrelated — reproduced on the unmodified tree:

* `test/05_workflows/test_workflow_manager.py::test_distribute_workflow`
* `test/05_workflows/test_workflow_manager_bugfixes.py::test_distribute_workflow_does_not_change_the_given_placements`

Both die in `geokit.location.splitKMeans` -> `sklearn.cluster.KMeans` -> `threadpoolctl` with `Windows fatal exception: code 0xc06d007f`, an MKL/OpenMP loading problem in the local environment.

> Note: the branch is named `chore/ruff-isort-import-sorting` from when this PR also carried the reordering commit. The name no longer matches the contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
